### PR TITLE
Message regex should accept strings containing multiple dots

### DIFF
--- a/JsHintTask.php
+++ b/JsHintTask.php
@@ -123,7 +123,7 @@ class JsHintTask extends Task {
 			
 			foreach ($messages as $message) {
 				$matches = array();
-				if (preg_match('/^([^:]+):\sline\s([^,]+),\scol\s([^,]+),([^\.]+)\.$/', $message, $matches)) {
+				if (preg_match('/^([^:]+):\sline\s([^,]+),\scol\s([^,]+),(.*)\.$/', $message, $matches)) {
 					$error = array('filename' => $matches[1], 'line' => $matches[2], 'column' => $matches[3], 'message' => $matches[4]);
 					$this->log('- line ' . $error['line'] . (isset($error['column']) ? ' column ' . $error['column'] : '') . ': ' . $error['message'], Project::MSG_ERR);
 				}


### PR DESCRIPTION
When JSHint reports results such as the following line, the original regular expression was unable
to retrieve details like line and column, thereby reporting only the number of errors without any
debugging information.

``` Shell
public/wp-content/themes/miljo/js/miljo.js: line 75, col 18, Creating global 'for' variable. Should be 'for (var i ...'.
```

This is resolved by using a regular expression that accepts anything in the last column, instead of anything
except dots.
